### PR TITLE
feat(ocr): ScanCompany 讀公司登記文件，附件改由呼叫端指定 MIME

### DIFF
--- a/client/gemini/client.go
+++ b/client/gemini/client.go
@@ -55,8 +55,16 @@ func (c *Client) Generate(ctx context.Context, message models.AIChatMessage, opt
 		contentParts = append(contentParts, genai.NewPartFromText(message.Text))
 	}
 
+	for _, f := range message.Files {
+		data, err := util.DownloadFile(ctx, f.URL)
+		if err != nil {
+			return "", fmt.Errorf("failed to download file: %w", err)
+		}
+		contentParts = append(contentParts, genai.NewPartFromBytes(data, f.MimeType))
+	}
+
 	for _, url := range message.ImageUrls {
-		imageData, err := util.DownloadImage(ctx, url)
+		imageData, err := util.DownloadFile(ctx, url)
 		if err != nil {
 			return "", fmt.Errorf("failed to download image: %w", err)
 		}

--- a/client/gemini/client.go
+++ b/client/gemini/client.go
@@ -56,20 +56,19 @@ func (c *Client) Generate(ctx context.Context, message models.AIChatMessage, opt
 	}
 
 	for _, f := range message.Files {
-		data, err := util.DownloadFile(ctx, f.URL)
+		data, served, err := util.DownloadFile(ctx, f.URL)
 		if err != nil {
 			return "", fmt.Errorf("failed to download file: %w", err)
 		}
-		contentParts = append(contentParts, genai.NewPartFromBytes(data, f.MimeType))
+		contentParts = append(contentParts, genai.NewPartFromBytes(data, mimeType(f.MimeType, served, data)))
 	}
 
 	for _, url := range message.ImageUrls {
-		imageData, err := util.DownloadFile(ctx, url)
+		imageData, served, err := util.DownloadFile(ctx, url)
 		if err != nil {
 			return "", fmt.Errorf("failed to download image: %w", err)
 		}
-		mimeType := http.DetectContentType(imageData)
-		contentParts = append(contentParts, genai.NewPartFromBytes(imageData, mimeType))
+		contentParts = append(contentParts, genai.NewPartFromBytes(imageData, mimeType("", served, imageData)))
 	}
 
 	contents := []*genai.Content{
@@ -113,4 +112,17 @@ func (c *Client) Generate(ctx context.Context, message models.AIChatMessage, opt
 	}
 
 	return resultText.String(), nil
+}
+
+// mimeType picks the most trustworthy answer available. Sniffing is last: Go's
+// table has no HEIC, so an iPhone photo would go out as octet-stream and read
+// as nothing.
+func mimeType(stated, served string, data []byte) string {
+	if stated != "" {
+		return stated
+	}
+	if served != "" && served != "application/octet-stream" {
+		return strings.TrimSpace(strings.Split(served, ";")[0])
+	}
+	return http.DetectContentType(data)
 }

--- a/client/gemini/mime_test.go
+++ b/client/gemini/mime_test.go
@@ -1,0 +1,25 @@
+package gemini
+
+import "testing"
+
+func TestMimeType(t *testing.T) {
+	heic := []byte("\x00\x00\x00\x18ftypheic")
+
+	cases := []struct {
+		name           string
+		stated, served string
+		data           []byte
+		want           string
+	}{
+		{"呼叫端說了就聽它的", "image/heic", "application/pdf", heic, "image/heic"},
+		{"沒說就用伺服器給的", "", "image/heic", heic, "image/heic"},
+		{"伺服器的值帶 charset 要剝掉", "", "text/plain; charset=utf-8", []byte("hi"), "text/plain"},
+		{"伺服器給 octet-stream 等於沒說", "", "application/octet-stream", []byte("%PDF-1.4"), "application/pdf"},
+		{"都沒有才嗅探", "", "", []byte("%PDF-1.4"), "application/pdf"},
+	}
+	for _, c := range cases {
+		if got := mimeType(c.stated, c.served, c.data); got != c.want {
+			t.Errorf("%s: got %q, want %q", c.name, got, c.want)
+		}
+	}
+}

--- a/client/openai/client.go
+++ b/client/openai/client.go
@@ -48,6 +48,12 @@ func (c *Client) Generate(ctx context.Context, message models.AIChatMessage, opt
 		userContentParts = append(userContentParts, openai.TextContentPart(message.Text))
 	}
 
+	// Rejected rather than ignored: a dropped attachment leaves the model
+	// answering a prompt with nothing to look at.
+	if len(message.Files) > 0 {
+		return "", fmt.Errorf("openai: Files not supported, use ImageUrls")
+	}
+
 	for _, url := range message.ImageUrls {
 		userContentParts = append(userContentParts, openai.ImageContentPart(
 			openai.ChatCompletionContentPartImageImageURLParam{

--- a/models/ai_client.go
+++ b/models/ai_client.go
@@ -11,7 +11,7 @@ type AIChatMessage struct {
 	SystemPrompt string
 	Text         string
 	Files        []InputFile
-	// ImageUrls is the older, sniffed form kept for existing callers.
+	// Deprecated: use Files, which states the type instead of sniffing it.
 	ImageUrls []string
 }
 

--- a/models/ai_client.go
+++ b/models/ai_client.go
@@ -1,9 +1,18 @@
 package models
 
+// InputFile is one attachment with its type stated by the caller. Sniffing is
+// not enough — Go's table has no HEIC, so an iPhone photo reads as nothing.
+type InputFile struct {
+	URL      string
+	MimeType string
+}
+
 type AIChatMessage struct {
 	SystemPrompt string
 	Text         string
-	ImageUrls    []string
+	Files        []InputFile
+	// ImageUrls is the older, sniffed form kept for existing callers.
+	ImageUrls []string
 }
 
 type ResponseFormat string

--- a/models/ocr.go
+++ b/models/ocr.go
@@ -159,3 +159,23 @@ const pharInfoPrompt = `
   "valid_date": "YYYY-MM-DD"
 }
 	`
+
+// CompanyInfo is what a registration document states; nil when it does not.
+type CompanyInfo struct {
+	CompanyName *string `json:"company_name"`
+	TaxID       *string `json:"tax_id"`
+}
+
+const CompanyPrompt = `
+這是一份公司或商業登記文件（可能是公司登記表、商業登記抄本、營業人銷售額與稅額申報書、
+或醫療器材商許可執照），請辨識以下兩個欄位，並以 JSON 格式輸出：
+{
+  "company_name": "登記的公司或商號全名",
+  "tax_id": "統一編號，8 位數字"
+}
+
+規則：
+- company_name 要完整登記名稱，包含「股份有限公司」「有限公司」「商行」等組織形式。
+- tax_id 只輸出 8 位數字，不含任何符號或文字。
+- 找不到的欄位請輸出空字串，不要臆測、不要從其他欄位推算。
+`

--- a/store/ocr.go
+++ b/store/ocr.go
@@ -70,6 +70,45 @@ func (s *ocrStore) ScanName(ctx context.Context, link string) (string, error) {
 	return result.Name, nil
 }
 
+func (s *ocrStore) ScanCompany(ctx context.Context, file models.InputFile) (*models.CompanyInfo, error) {
+	if s.aiClient == nil {
+		return nil, fmt.Errorf("AI client is not initialized")
+	}
+
+	message := models.AIChatMessage{
+		SystemPrompt: models.SystemContent,
+		Text:         models.CompanyPrompt,
+		Files:        []models.InputFile{file},
+	}
+
+	opts := models.AIClientOptions{
+		MaxTokens:      s.cfg.MaxToken,
+		ResponseFormat: models.ResponseFormatJSON,
+	}
+
+	resp, err := s.aiClient.Generate(ctx, message, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	raw := struct {
+		CompanyName string `json:"company_name"`
+		TaxID       string `json:"tax_id"`
+	}{}
+	if err := json.Unmarshal([]byte(resp), &raw); err != nil {
+		return nil, err
+	}
+
+	info := models.CompanyInfo{}
+	if raw.CompanyName != "" {
+		info.CompanyName = &raw.CompanyName
+	}
+	if raw.TaxID != "" {
+		info.TaxID = &raw.TaxID
+	}
+	return &info, nil
+}
+
 func (s *ocrStore) ScanRawInfo(ctx context.Context, userID string, link string, platformType models.PlatformType) (*models.OCRRawInfo, error) {
 	if s.aiClient == nil {
 		return nil, fmt.Errorf("AI client is not initialized")

--- a/store/ocr_test.go
+++ b/store/ocr_test.go
@@ -1,0 +1,69 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/A-pen-app/ai-client/models"
+)
+
+// fakeAIClient returns a canned response and records what it was asked.
+type fakeAIClient struct {
+	resp string
+	err  error
+	got  models.AIChatMessage
+}
+
+func (f *fakeAIClient) Generate(_ context.Context, m models.AIChatMessage, _ models.AIClientOptions) (string, error) {
+	f.got = m
+	return f.resp, f.err
+}
+
+func TestScanCompany(t *testing.T) {
+	file := models.InputFile{URL: "https://example.com/a.heic", MimeType: "image/heic"}
+
+	t.Run("兩個欄位都讀到", func(t *testing.T) {
+		c := &fakeAIClient{resp: `{"company_name":"聯合醫療器材行","tax_id":"04595257"}`}
+		got, err := NewOcrStore(nil, c, nil).ScanCompany(context.Background(), file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.CompanyName == nil || *got.CompanyName != "聯合醫療器材行" {
+			t.Errorf("company_name = %v", got.CompanyName)
+		}
+		if got.TaxID == nil || *got.TaxID != "04595257" {
+			t.Errorf("tax_id = %v", got.TaxID)
+		}
+	})
+
+	t.Run("讀不到的欄位是 nil 而不是空字串", func(t *testing.T) {
+		c := &fakeAIClient{resp: `{"company_name":"聯合醫療器材行","tax_id":""}`}
+		got, err := NewOcrStore(nil, c, nil).ScanCompany(context.Background(), file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.TaxID != nil {
+			t.Errorf("tax_id = %v, want nil", *got.TaxID)
+		}
+	})
+
+	t.Run("附件帶著呼叫端給的 MIME，不靠嗅探", func(t *testing.T) {
+		c := &fakeAIClient{resp: `{"company_name":"x","tax_id":""}`}
+		if _, err := NewOcrStore(nil, c, nil).ScanCompany(context.Background(), file); err != nil {
+			t.Fatal(err)
+		}
+		if len(c.got.Files) != 1 || c.got.Files[0].MimeType != "image/heic" {
+			t.Errorf("files = %+v", c.got.Files)
+		}
+		if len(c.got.ImageUrls) != 0 {
+			t.Errorf("不該走舊的 ImageUrls: %v", c.got.ImageUrls)
+		}
+	})
+
+	t.Run("模型回非 JSON 就回錯", func(t *testing.T) {
+		c := &fakeAIClient{resp: `抱歉，我看不懂這份文件`}
+		if _, err := NewOcrStore(nil, c, nil).ScanCompany(context.Background(), file); err == nil {
+			t.Error("want error")
+		}
+	})
+}

--- a/store/store.go
+++ b/store/store.go
@@ -8,6 +8,9 @@ import (
 
 type OCR interface {
 	ScanName(ctx context.Context, link string) (string, error)
+	// ScanCompany reads the company name and tax id off one registration
+	// document. Matching them against anything is the caller's business.
+	ScanCompany(ctx context.Context, file models.InputFile) (*models.CompanyInfo, error)
 	ScanRawInfo(ctx context.Context, userID string, link string, professionType models.PlatformType) (*models.OCRRawInfo, error)
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -12,8 +12,8 @@ var httpClient = &http.Client{
 	Timeout: time.Second * 30,
 }
 
-// DownloadImage downloads an image from a URL and returns the image data
-func DownloadImage(ctx context.Context, url string) ([]byte, error) {
+// DownloadFile downloads a file from a URL and returns its bytes.
+func DownloadFile(ctx context.Context, url string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
@@ -21,17 +21,17 @@ func DownloadImage(ctx context.Context, url string) ([]byte, error) {
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to download image: %w", err)
+		return nil, fmt.Errorf("failed to download file: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to download image: status code %d", resp.StatusCode)
+		return nil, fmt.Errorf("failed to download file: status code %d", resp.StatusCode)
 	}
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read image data: %w", err)
+		return nil, fmt.Errorf("failed to read file: %w", err)
 	}
 
 	return data, nil

--- a/util/util.go
+++ b/util/util.go
@@ -12,27 +12,28 @@ var httpClient = &http.Client{
 	Timeout: time.Second * 30,
 }
 
-// DownloadFile downloads a file from a URL and returns its bytes.
-func DownloadFile(ctx context.Context, url string) ([]byte, error) {
+// DownloadFile downloads a file and returns its bytes with the Content-Type the
+// server stated, which beats sniffing for anything Go's table does not know.
+func DownloadFile(ctx context.Context, url string) ([]byte, string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, "", fmt.Errorf("failed to create request: %w", err)
 	}
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to download file: %w", err)
+		return nil, "", fmt.Errorf("failed to download file: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to download file: status code %d", resp.StatusCode)
+		return nil, "", fmt.Errorf("failed to download file: status code %d", resp.StatusCode)
 	}
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read file: %w", err)
+		return nil, "", fmt.Errorf("failed to read file: %w", err)
 	}
 
-	return data, nil
+	return data, resp.Header.Get("Content-Type"), nil
 }


### PR DESCRIPTION
medgo 的廠商審核要對認證文件做 OCR，取出**公司登記名稱與統一編號**與廠商自己填的值比對。

## 為什麼不沿用既有兩支

```go
ScanName(ctx, link) (string, error)                                 // 只回名字
ScanRawInfo(ctx, userID, link, professionType) (*OCRRawInfo, error) // 醫事人員執業執照
```

`OCRRawInfo` 的欄位是 `Name`／`Birthday`／`Position`／`Department`／`Facility`／`ValidDate`——為執業執照設計的，**沒有統一編號**，`Facility` 是服務院所不是公司登記名稱。

## `ScanCompany`

```go
ScanCompany(ctx context.Context, file models.InputFile) (*models.CompanyInfo, error)

type CompanyInfo struct {
    CompanyName *string `json:"company_name"`
    TaxID       *string `json:"tax_id"`
}
```

**一次一份文件、只回文件上寫什麼。** 「多份任一份對不上即整體不符」「沒填統編時只比名稱」是呼叫端的業務規則，不該讓 SDK 知道——三平台日後要用也不會被綁住。

不發 pub/sub（`ScanRawInfo` 會送 OCR 事件是因為 apen 的認證流程要，這支沒有下游）。

## 附件改由呼叫端指定 MIME

```go
type InputFile struct {
    URL      string
    MimeType string
}
```

gemini client 原本是 `http.DetectContentType` 嗅探，而 **Go 的嗅探表沒有 HEIC**（ISO BMFF 容器）——iPhone 拍的文件會被判成 `application/octet-stream`，模型收到辨識不出內容。**不會報錯，只是安靜地讀不到東西。**

呼叫端本來就知道型別（medgo 的 `vendor_documents.content_type` 存的就是上傳當下判定的值），讓它講明比讓 SDK 猜可靠。

- `ImageUrls` 保留給既有呼叫端（apen 的 `ScanName`／`ScanRawInfo`），走原本的嗅探，行為不變
- openai client 沒有 `Files` 的路徑，**明確回錯**而不是靜默忽略——丟掉附件會讓模型對著一段沒有檔案的提示亂答
- `util.DownloadImage` → `DownloadFile`，它早就不只下載圖片

## 合併後

要 tag 一個版本，medgo 才 bump 得動。