### PR TITLE
feat(ocr)!: let the caller name the topic ScanRawInfo publishes to

### DIFF
--- a/store/ocr.go
+++ b/store/ocr.go
@@ -14,7 +14,9 @@ import (
 
 type Config struct {
 	MaxToken int64
-	IsProd   bool
+	// Topic is where ScanRawInfo publishes its result; empty publishes nothing.
+	// mq accepts a projects/<project>/topics/<topic> path for another project.
+	Topic string
 }
 
 type ocrStore struct {
@@ -27,7 +29,6 @@ func NewOcrStore(mq mq.MQ, aiClient AIClient, config *Config) OCR {
 	if config == nil {
 		config = &Config{
 			MaxToken: 1024,
-			IsProd:   false,
 		}
 	}
 
@@ -141,19 +142,16 @@ func (s *ocrStore) ScanRawInfo(ctx context.Context, userID string, link string, 
 		return nil, err
 	}
 
-	ocrTopic := models.OCRTopicDev
-	if s.cfg.IsProd {
-		ocrTopic = models.OCRTopicProd
-	}
-
-	if err := s.mq.Send(string(ocrTopic), models.OCREventMessage{
-		UserID:    userID,
-		Payload:   modifiedJSON,
-		CreatedAt: time.Now(),
-		Type:      string(models.OCRMessageTypeIdentifyOCR),
-		Source:    string(platformType),
-	}); err != nil {
-		logging.Errorw(ctx, "Failed to send ocr result", "error", err)
+	if s.cfg.Topic != "" {
+		if err := s.mq.Send(s.cfg.Topic, models.OCREventMessage{
+			UserID:    userID,
+			Payload:   modifiedJSON,
+			CreatedAt: time.Now(),
+			Type:      string(models.OCRMessageTypeIdentifyOCR),
+			Source:    string(platformType),
+		}); err != nil {
+			logging.Errorw(ctx, "Failed to send ocr result", "error", err, "topic", s.cfg.Topic)
+		}
 	}
 
 	ocr := models.OCRRawInfo{}

--- a/store/ocr_test.go
+++ b/store/ocr_test.go
@@ -2,9 +2,11 @@ package store
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/A-pen-app/ai-client/models"
+	mqmodels "github.com/A-pen-app/mq/v2/models"
 )
 
 // fakeAIClient returns a canned response and records what it was asked.
@@ -66,4 +68,52 @@ func TestScanCompany(t *testing.T) {
 			t.Error("want error")
 		}
 	})
+}
+
+// fakeMQ records the topics it was asked to publish to.
+type fakeMQ struct {
+	topics []string
+}
+
+func (f *fakeMQ) Send(topic string, _ interface{}, _ ...mqmodels.GetMQOption) error {
+	f.topics = append(f.topics, topic)
+	return nil
+}
+
+func (f *fakeMQ) SendWithContext(_ context.Context, topic string, data interface{}, opts ...mqmodels.GetMQOption) error {
+	return f.Send(topic, data, opts...)
+}
+
+func (f *fakeMQ) Receive(string) (<-chan []byte, error) { return nil, nil }
+
+func (f *fakeMQ) ReceiveWithContext(context.Context, string) (<-chan []byte, error) {
+	return nil, nil
+}
+
+func TestScanRawInfoPublishesWhereTheCallerSaid(t *testing.T) {
+	cases := []struct {
+		name  string
+		topic string
+		want  []string
+	}{
+		{"沒設 topic 就不發佈", "", nil},
+		{"發到設定的 topic", string(models.OCRTopicDev), []string{"wanderer-dev"}},
+		{"跨專案路徑原樣送出", "projects/penpeer-production/topics/wanderer", []string{"projects/penpeer-production/topics/wanderer"}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ai := &fakeAIClient{resp: `{"name":"王小明","birthday":"1990-01-01"}`}
+			m := &fakeMQ{}
+
+			store := NewOcrStore(m, ai, &Config{MaxToken: 1024, Topic: c.topic})
+			if _, err := store.ScanRawInfo(context.Background(), "u1", "https://example.com/licence.jpg", models.PlatformTypeApen); err != nil {
+				t.Fatal(err)
+			}
+
+			if !slices.Equal(m.topics, c.want) {
+				t.Errorf("published to %v, want %v", m.topics, c.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## 問題

`ScanRawInfo` 用 `Config.IsProd` 猜自己被部署在哪個環境，再從這個套件自己定義的兩個名字（`wanderer-dev` / `wanderer-prod`）裡挑一個。

這個猜法在 topic 搬家時就不成立了：分析專案上的那條串流叫 **`wanderer`**，沒有環境後綴——因為專案本身就是環境。呼叫端沒有任何辦法表達這件事。

## 改動

`Config.IsProd` 換成 `Config.Topic`，發到哪由呼叫端說。

```go
type Config struct {
	MaxToken int64
	// Topic is where ScanRawInfo publishes its result; empty publishes nothing.
	// mq accepts a projects/<project>/topics/<topic> path for another project.
	Topic string
}
```

mq 會把 `projects/<p>/topics/<t>` 解析到那個專案，所以**一個字串同時涵蓋「換名字」和「換專案」**，不需要多開欄位。更重要的是呼叫端可以把同一個值同時用在自己的 mq topic 註冊上，兩邊不可能再對「現在是哪個環境」有不同看法——目前 apen 就是 `main.go` 用 `PRODUCTION_ENVIRONMENT && GIN_MODE`、這裡用 `GIN_MODE`，兩種寫法並存。

空字串不發佈。

## 影響

**BREAKING**：`Config.IsProd` 消失。

- **apen / phar / nurse** 會發佈，要改成傳 topic（跟它們在 mq 註冊的同一個值）
- **medgo 零改動**：它只呼叫 `ScanCompany`，從來沒走到這段程式碼；`&aistore.Config{MaxToken: ocrMaxTokens}` 照樣編譯，而空 Topic 等於不發佈，跟它現在的實際行為一致

## 測試

新增 `TestScanRawInfoPublishesWhereTheCallerSaid`，三個 case：沒設 topic 不發佈、發到設定的 topic、跨專案路徑原樣送出。附一個記錄 topic 的 `fakeMQ`。

順帶：改完之後 `ScanRawInfo` 可以用 nil mq 測——以前 `IsProd: false` 會直接對 nil interface 呼叫 `Send`。

## 保留

`models.OCRTopicDev` / `OCRTopicProd` 兩個常數留著（拿掉是另一次 breaking）。但 `OCRTopicProd`（`wanderer-prod`）之後不該再被使用，prod 會走完整路徑指向 `penpeer-production/wanderer`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiusTcfUSp2vcbmdr2JHhB